### PR TITLE
Add ability to connect to MongoDB service using username / password authentication

### DIFF
--- a/src/Zizaco/MongolidLaravel/MongolidServiceProvider.php
+++ b/src/Zizaco/MongolidLaravel/MongolidServiceProvider.php
@@ -34,12 +34,26 @@ class MongolidServiceProvider extends ServiceProvider {
     {
         $config = $this->app->make('config');
 
-        $connectionString = 'mongodb://'.
-            $config->get('database.mongodb.default.host', '127.0.0.1').
+        $connectionString = 'mongodb://';
+        
+        /*
+		 * DIRTY HACK
+		 * The following code could be re-imagined, probably way better than I have
+		 * and allows connections to MongoDB instances with authentication using
+		 * a username and password
+		 */
+        if( $config->get('database.mongodb.default.username', '' ) != "" ) {
+            $connectionString .= $config->get('database.mongodb.default.username', '').
             ':'.
-            $config->get('database.mongodb.default.port', 27017).
-            '/'.
-            $config->get('database.mongodb.default.database', 'mongolid');
+            $config->get('database.mongodb.default.password', '').
+            '@';
+        }
+        
+        $connectionString .= $config->get('database.mongodb.default.host', '127.0.0.1').
+        ':'.
+        $config->get('database.mongodb.default.port', 27017).
+        '/'.
+        $config->get('database.mongodb.default.database', 'mongolid');
 
         $connection = new MongoDbConnector;
         $connection->getConnection( $connectionString );


### PR DESCRIPTION
This pull request adds the ability for MongoLid to connect to MongoDB instances that use username and password authentication, such as the ones provided by MongoHQ.

This code is really dirty, and there is probably a much better way of doing this! Added this pull request to see if this feature can be added.
