### PR TITLE
possible confirmation field fix

### DIFF
--- a/src/Zizaco/MongolidLaravel/MongoLid.php
+++ b/src/Zizaco/MongolidLaravel/MongoLid.php
@@ -168,7 +168,7 @@ abstract class MongoLid extends \Zizaco\Mongolid\Model
             /**
              * Removes any confirmation field before saving it into the database
              */
-            $confirmationField = $attr.'_password_confirmation';
+            $confirmationField = $attr.'_confirmation';
             if($this->$confirmationField) {
                 unset($this->$confirmationField);
             }


### PR DESCRIPTION
I'm using your Confide-Mongo project and the confirmation fields are not being removed from the User model when it gets saved.
