### PR TITLE
Fix retrieveByCredentials() to return expected type

### DIFF
--- a/src/Zizaco/MongolidLaravel/MongoLidUserProvider.php
+++ b/src/Zizaco/MongolidLaravel/MongoLidUserProvider.php
@@ -54,8 +54,9 @@ class MongoLidUserProvider implements UserProviderInterface
     public function retrieveByCredentials(array $credentials)
     {
         unset($credentials['password']);
-
-        return $this->createModel()->first($credentials);
+        
+        $result = $this->createModel()->first($credentials);
+        return $result ? $result : null;
     }
 
     /**


### PR DESCRIPTION
`retrieveByCredentials()` must return either `UserInterface` or `null`, but `first()` returns boolean `false` if credentials are not found. If a boolean value is received by `Illuminate\Auth\Guard::hasValidCredentials()` an error exception is thrown.
