### PR TITLE
Suport for mongoDB cluster connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ In your `config/app.php` add `'MongolidLaravel\MongolidServiceProvider'` to the 
 ],
 ```
 
-And least, be sure to configure a database connection in `config/database.php`:
+Lastly, be sure to configure a database connection in `config/database.php`:
 
 Paste the settings bellow at the end of your `config/database.php`, before the last `];`:
 
@@ -122,8 +122,7 @@ For cluster with automatic failover, you need to set `cluster` key containing al
 You can configure as much nodes are needed, `primary` and `secondary` nodes names are optional.
 
 
-> **Note:** If you don't specify the key above in your `config/database.php`.
-The MongoLid will automatically try to connect to 127.0.0.1:27017 and use a database named 'mongolid'.
+> **Note:** If you don't specify the `mongodb` key in your `config/database.php` MongoLid will automatically try to connect to '127.0.0.1:27017' and use a database named 'mongolid'.
 
 You may optionally provide a `connectionString` key to set a fully-assembled connection string that will override all other connection options. More info about connection string are found in [MongoDB documentation](https://docs.mongodb.com/manual/reference/connection-string/).
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Paste the settings bellow at the end of your `config/database.php`, before the l
 ],
 ```
 
-For cluster with automatic failover, you need to set `cluster` key containing all hosts along with replica set name.
+For cluster with automatic failover, you need to set `cluster` key containing all `nodes` along with `replica_set` name.
 
 ```php
 'mongodb' => [
     'default' => [
         'cluster' => [
-            'replicaSet' => env('DB_REPLICA_SET', ''),
+            'replica_set' => env('DB_REPLICA_SET', ''),
             'nodes' => [
                 'primary' => [
                     'host' => env('DB_HOST_A', 'host-a'),
@@ -119,8 +119,7 @@ For cluster with automatic failover, you need to set `cluster` key containing al
 ],
 ```
 
-You can configure as much nodes are needed, `primary` and `secondary` nodes names are optional.
-
+You can configure as much nodes as needed, node names (e.g. `primary` and `secondary` ) are optional.
 
 > **Note:** If you don't specify the `mongodb` key in your `config/database.php` MongoLid will automatically try to connect to '127.0.0.1:27017' and use a database named 'mongolid'.
 
@@ -134,7 +133,7 @@ You may optionally provide a `connectionString` key to set a fully-assembled con
 ],
 ```
 
-Also, it is possible to pass `options` and `driver_options` to MongoDB Client. Mongolid always overrides `typeMap` configuration of driver options to `array` because makes easier to use internally in Mongolid. Possible options and driver options are present on [`MongoDB\Client` documentation](https://docs.mongodb.com/php-library/master/reference/method/MongoDBClient__construct/).
+Also, it is possible to pass `options` and `driver_options` to MongoDB Client. Mongolid always overrides `typeMap` configuration of `driver_options` to `array` because it makes easier to use internally with models. Possible `options` and `driver_options` are present on [`MongoDB\Client` documentation](https://docs.mongodb.com/php-library/master/reference/method/MongoDBClient__construct/).
 
 ## Basic Usage
 
@@ -182,7 +181,7 @@ and make sure that the class specified in `model` is a MongoLid model that imple
 
 ```
 
-The `User` model should implement the `Authenticatable` contract:
+The `User` model should implement the `Authenticatable` interface:
 
 ```php
 <?php
@@ -271,7 +270,7 @@ You can use [any method regarding authentication](https://laravel.com/docs/5.2/a
 
 **"PHP Fatal error: Class 'MongoDB\Client' not found in ..."**
 
-The `MongoDB\Client` class is contained in the [MongoDB PHP Library](https://docs.mongodb.com/php-library/master/) and requires [MongoDB driver](https://pecl.php.net/package/mongodb) for PHP.
+The `MongoDB\Client` class is contained in the [MongoDB PHP Library](https://docs.mongodb.com/php-library/master/) and it requires [MongoDB driver for PHP](https://pecl.php.net/package/mongodb).
 Here is an [installation guide](http://php.net/manual/en/mongodb.setup.php) for this driver.
 The driver is a PHP extension written in C and maintained by [MongoDB](https://mongodb.com).
 MongoLid and most other MongoDB PHP libraries utilize it in order to be fast and reliable.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In your `config/app.php` add `'MongolidLaravel\MongolidServiceProvider'` to the 
 
 And least, be sure to configure a database connection in `config/database.php`:
 
-Paste the settings bellow at the end of your `config/database.php`, before the last `);`:
+Paste the settings bellow at the end of your `config/database.php`, before the last `];`:
 
 **Notice:** It must be **outside** of `connections` array.
 
@@ -77,7 +77,12 @@ Paste the settings bellow at the end of your `config/database.php`, before the l
 | MongoDB Databases
 |--------------------------------------------------------------------------
 |
+| MongoDB is a document database with the scalability and flexibility
+| that you want with the querying and indexing that you need.
+| Mongolid Laravel use this config to starting querying right now.
+|
 */
+
 'mongodb' => [
     'default' => [
         'host'     => env('DB_HOST', '127.0.0.1'),
@@ -89,10 +94,48 @@ Paste the settings bellow at the end of your `config/database.php`, before the l
 ],
 ```
 
+For cluster with automatic failover, you need to set `cluster` key containing all hosts along with replica set name.
+
+```php
+'mongodb' => [
+    'default' => [
+        'cluster' => [
+            'replicaSet' => env('DB_REPLICA_SET', ''),
+            'nodes' => [
+                'primary' => [
+                    'host' => env('DB_HOST_A', 'host-a'),
+                    'port' => env('DB_PORT_A', 27017),
+                ],
+                'secondary' => [
+                    'host' => env('DB_HOST_B', 'host-b'),
+                    'port' => env('DB_PORT_B', 27017),
+                ],
+            ],
+        ],
+        'database' => env('DB_DATABASE', 'mongolid'),
+        'username' => env('DB_USERNAME', ''),
+        'password' => env('DB_PASSWORD', ''),
+    ],
+],
+```
+
+You can configure as much nodes are needed, `primary` and `secondary` nodes names are optional.
+
+
 > **Note:** If you don't specify the key above in your `config/database.php`.
 The MongoLid will automatically try to connect to 127.0.0.1:27017 and use a database named 'mongolid'.
 
-You may optionally provide a `connectionString` key to set a fully-assembled connection string (useful for configuring fun things like read preference, replica sets, etc.) this will override all other connection options.
+You may optionally provide a `connectionString` key to set a fully-assembled connection string that will override all other connection options. More info about connection string are found in [MongoDB documentation](https://docs.mongodb.com/manual/reference/connection-string/).
+
+```php
+'mongodb' => [
+    'default' => [
+        'connectionString' => 'mongodb://host-a:27017,host-b:27917/mongolid?replicaSet=rs-ds123',
+    ],
+],
+```
+
+Also, it is possible to pass `options` and `driver_options` to MongoDB Client. Mongolid always overrides `typeMap` configuration of driver options to `array` because makes easier to use internally in Mongolid. Possible options and driver options are present on [`MongoDB\Client` documentation](https://docs.mongodb.com/php-library/master/reference/method/MongoDBClient__construct/).
 
 ## Basic Usage
 
@@ -115,7 +158,7 @@ class User extends MongolidModel
 In a nutshell, that's it!
 
 ### For further reading about models, CRUD operations, relationships and more, check the [Read the Docs: <small>leroy-merlin-br.github.com/mongolid</small>](http://leroy-merlin-br.github.io/mongolid/).
-[![Mongolid Docs](https://dl.dropboxusercontent.com/u/12506137/libs_bundles/MongolidDocs.png)](http://leroy-merlin-br.github.com/mongolid)
+[![Mongolid Docs](https://user-images.githubusercontent.com/1991286/28967747-fe5c258a-78f2-11e7-91c7-8850ffb32004.png)](http://leroy-merlin-br.github.com/mongolid)
 
 ## Authentication
 
@@ -229,8 +272,8 @@ You can use [any method regarding authentication](https://laravel.com/docs/5.2/a
 
 **"PHP Fatal error: Class 'MongoDB\Client' not found in ..."**
 
-The `MongoDB\Client` class is contained in the [MongoDB driver](https://pecl.php.net/package/mongodb) for PHP.
-[Here is an installation guide](http://php.net/manual/en/mongodb.setup.php).
+The `MongoDB\Client` class is contained in the [MongoDB PHP Library](https://docs.mongodb.com/php-library/master/) and requires [MongoDB driver](https://pecl.php.net/package/mongodb) for PHP.
+Here is an [installation guide](http://php.net/manual/en/mongodb.setup.php) for this driver.
 The driver is a PHP extension written in C and maintained by [MongoDB](https://mongodb.com).
 MongoLid and most other MongoDB PHP libraries utilize it in order to be fast and reliable.
 
@@ -263,4 +306,4 @@ Mongolid was proudly built by the [Leroy Merlin Brazil](https://github.com/leroy
 
 Any questions, feel free to contact us.
 
-Any issues, please [report here](https://github.com/Zizaco/mongolid-laravel)
+Any issues, please [report here](https://github.com/leroy-merlin-br/mongolid-laravel/issues).

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -126,11 +126,11 @@ class MongolidServiceProvider extends ServiceProvider
     private function buildHostname(array $config): string
     {
         if (isset($config['cluster'])) {
-            foreach ($$config['cluster']['nodes'] as $node) {
+            foreach ($config['cluster']['nodes'] as $node) {
                 $nodes[] = sprintf(
                     '%s:%s',
-                    $config['host'] ?? '127.0.0.1',
-                    $config['port'] ?? 27017
+                    $node['host'] ?? '127.0.0.1',
+                    $node['port'] ?? 27017
                 );
             }
 

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -40,11 +40,15 @@ class MongolidServiceProvider extends ServiceProvider
      */
     public function registerConnector()
     {
-        $config = $this->app['config']->get('database.mongodb.default');
         MongolidIoc::setContainer($this->app);
 
+        $config = $this->app['config']->get('database.mongodb.default');
+
         $connectionString = $this->buildConnectionString($config);
-        $connection = new Connection($connectionString);
+        $options = $config['options'] ?? [];
+        $driverOptions = $config['driver_options'] ?? [];
+
+        $connection = new Connection($connectionString, $options, $driverOptions);
         $connection->defaultDatabase = $config['database'] ?? 'mongolid';
 
         $pool = new Pool();

--- a/tests/MongolidServiceProviderTest.php
+++ b/tests/MongolidServiceProviderTest.php
@@ -72,7 +72,7 @@ class MongolidServiceProviderTest extends TestCase
             'custom host and port' => [
                 'config' => [
                     'host' => 'localhost',
-                    'port' => 27917
+                    'port' => 27917,
                 ],
                 'connectionString' => 'mongodb://localhost:27917/mongolid',
             ],


### PR DESCRIPTION
To provide automatic failover, mongodb expect that all nodes be present on connection string, something like that:

```
mongodb://user:passwd@host-a:27017,host-b:27017/my_db?replicaSet=rs-prod
```

This PR adds the possibility to configura a mongodb cluster:

```
'mongodb' => [
    'default' => [
        'cluster' => [
            'replicaSet' => 'rs-ds123',
            'nodes' => [
                'primary' => [
                    'host' => env('DB_HOST_A', 'host-a'),
                    'port' => env('DB_PORT_A', 27017),
                ],
                'secondary' => [
                    'host' => env('DB_HOST_B', 'host-b'),
                    'port' => env('DB_PORT_B', 27017),
                ],
            ],
        ],
        'database' => env('DB_DATABASE', 'mongolid'),
        'username' => env('DB_USERNAME', ''),
        'password' => env('DB_PASSWORD', ''),
    ],
],
``` 
TODO:
 - [x] Add tests
 - [x] Update documentation
 - [x] Release a new beta tag (the last one I wish :smile:)