### PR TITLE
Add Package Discovery for MongoLid

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Make sure to set minimum stability to `dev` when using a beta tag (`composer con
 composer require leroy-merlin-br/mongolid-laravel=2.0.0-beta7
 ```
 
+> **Note**: If you are using Laravel 5.5, the next steps for providers and aliases are unnecessaries. MongoLid supports Laravel new [Package Discovery](https://laravel.com/docs/5.5/packages#package-discovery).
+
 In your `config/app.php` add `'MongolidLaravel\MongolidServiceProvider'` to the end of the `$providers` array
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,14 @@
     "extra": {
         "branch-alias": {
             "dev-master": "v2.0-dev"
+        },
+        "laravel": {
+            "providers": [
+                "MongolidLaravel\\MongolidServiceProvider"
+            ],
+            "aliases": {
+                "MongoLid": "MongolidLaravel\\MongoLidModel"
+            }
         }
     }
 }


### PR DESCRIPTION
In Laravel 5.5 [packages can now be auto discovery](https://laravel.com/docs/5.5/packages#package-discovery). This PR adds this functionality!

PS: I've already added documentation for this in README.md