### PR TITLE
Updated phpunit and mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "illuminate/queue": "^5.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "mockery/mockery": "^0.9",
+        "mockery/mockery": "~1.0",
         "orchestra/testbench": "^3.4",
+        "phpunit/phpunit": "~6.0",
         "satooshi/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,9 @@
         "illuminate/queue": "^5.4"
     },
     "require-dev": {
-        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "^6.0",
         "orchestra/testbench": "^3.4",
-        "phpunit/phpunit": "~6.0",
+        "mockery/mockery": "^1.0",
         "satooshi/php-coveralls": "^1.0"
     },
     "autoload": {

--- a/src/MongolidModel.php
+++ b/src/MongolidModel.php
@@ -218,7 +218,7 @@ abstract class MongolidModel extends ActiveRecord
      */
     public static function __callStatic($name, $arguments)
     {
-        if ($name === 'shouldReceive') {
+        if ('shouldReceive' === $name) {
             $class = get_called_class();
             static::$mock[$class] = static::$mock[$class] ?? Mockery::mock();
 
@@ -253,7 +253,7 @@ abstract class MongolidModel extends ActiveRecord
      */
     protected function hasLocalMock(): bool
     {
-        return $this->localMock !== null;
+        return null !== $this->localMock;
     }
 
     /**


### PR DESCRIPTION
Updated `phpunit/phpunit` to `~6.0` and `mockery/mockery` to `~1.0`. Also organized `require-dev` section alphabetically.