### PR TITLE
Second level cache

### DIFF
--- a/src/LaravelCacheComponent.php
+++ b/src/LaravelCacheComponent.php
@@ -7,10 +7,19 @@ use Mongolid\Util\CacheComponentInterface;
 use stdClass;
 
 /**
- * Wraps the Laravel's event Dispatcher in order to trigger Mongolid events.
+ * Wraps the Laravel's Cache Repository to implement Mongolid Interface.
+ * Add a second layer of cache in memory to avoid hitting
+ * Laravel's cache twice for large results.
  */
 class LaravelCacheComponent implements CacheComponentInterface
 {
+    /**
+     * Copy cache result in memory array.
+     *
+     * @var array
+     */
+    private $inMemoryCache = [];
+
     /**
      * Injects the dependencies of LaravelCacheComponent.
      *
@@ -30,7 +39,11 @@ class LaravelCacheComponent implements CacheComponentInterface
      */
     public function get(string $key)
     {
-        return $this->laravelCache->get($key, null);
+        if (isset($this->inMemoryCache[$key])) {
+            return $this->inMemoryCache[$key];
+        }
+
+        return $this->inMemoryCache[$key] = $this->laravelCache->get($key, null);
     }
 
     /**

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -62,7 +62,7 @@ class MongolidServiceProvider extends ServiceProvider
 
         $this->app->instance(Pool::class, $pool);
         $this->app->instance(EventTriggerService::class, $eventService);
-        $this->app->bind(CacheComponentInterface::class, function ($app) {
+        $this->app->singleton(CacheComponentInterface::class, function ($app) {
             return new LaravelCacheComponent($app[CacheRepository::class]);
         });
     }

--- a/tests/LaravelCacheComponentTest.php
+++ b/tests/LaravelCacheComponentTest.php
@@ -44,7 +44,6 @@ class LaravelCacheComponentTest extends TestCase
         $component->get($key);
         $result = $component->get($key);
 
-
         // Assertion
         $this->assertEquals($value, $result);
     }

--- a/tests/LaravelCacheComponentTest.php
+++ b/tests/LaravelCacheComponentTest.php
@@ -26,6 +26,29 @@ class LaravelCacheComponentTest extends TestCase
         $this->assertEquals($value, $component->get($key));
     }
 
+    public function testShouldGetFromInMemoryCache()
+    {
+        // Set
+        $cacheRepo = m::mock(Repository::class);
+        $component = new LaravelCacheComponent($cacheRepo);
+        $key = 'foo';
+        $value = 'bar';
+
+        // Expectations
+        $cacheRepo->shouldReceive('get')
+            ->once()
+            ->with($key, null)
+            ->andReturn($value);
+
+        // Actions
+        $component->get($key);
+        $result = $component->get($key);
+
+
+        // Assertion
+        $this->assertEquals($value, $result);
+    }
+
     public function testShouldPut()
     {
         // Set
@@ -50,15 +73,14 @@ class LaravelCacheComponentTest extends TestCase
         $cacheRepo = m::mock(Repository::class);
         $component = new LaravelCacheComponent($cacheRepo);
         $key = 'foo';
-        $exists = true;
 
         // Expectations
         $cacheRepo->shouldReceive('has')
             ->once()
             ->with($key)
-            ->andReturn($exists);
+            ->andReturn(true);
 
         // Assertion
-        $this->assertEquals($exists, $component->has($key));
+        $this->assertTrue($component->has($key));
     }
 }


### PR DESCRIPTION
We use Cache component to avoid querying MongoDB multiple times for a small amount of time.

Even for a external cache it could be very onerous with large results processed multiple times on a same request. To minimize those effects a second level in memory cache as array could minimize this too. 