### PR TITLE
Validation rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
-  - if [[ $TRAVIS_PHP_VERSION = 7.0 ]]; then pecl install mongodb; fi
   - echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "leroy-merlin-br/mongolid": "^2.0",
         "illuminate/support": "^5.4",
         "illuminate/auth": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         }
     },
     "autoload-dev": {
-        "classmap": [
-            "tests"
-        ]
+        "psr-4": {
+            "MongolidLaravel\\": "tests"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/MongolidModel.php
+++ b/src/MongolidModel.php
@@ -34,14 +34,14 @@ abstract class MongolidModel extends ActiveRecord
      *
      * @var array
      */
-    public $rules = null;
+    protected $rules;
 
     /**
      * Error message bag.
      *
      * @var MessageBag
      */
-    public $errors;
+    protected $errors;
 
     /**
      * Public static mock.
@@ -123,14 +123,11 @@ abstract class MongolidModel extends ActiveRecord
      */
     public function isValid()
     {
-        // Return true if there aren't validation rules
-        if (!is_array($this->rules)) {
+        if (!$rules = $this->rules()) {
             return true;
         }
 
-        // Get the attributes and the rules to validate then
-        $attributes = $this->attributes;
-        $rules = $this->rules;
+        $attributes = $this->getAttributes();
 
         // Verify attributes that are hashed and that have not changed
         // those doesn't need to be validated.
@@ -163,6 +160,14 @@ abstract class MongolidModel extends ActiveRecord
         }
 
         return $this->errors;
+    }
+
+    /**
+     * Get the contents of rules attribute.
+     */
+    public function rules(): array
+    {
+        return $this->rules ?? [];
     }
 
     /**

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -203,12 +203,16 @@ class MongolidServiceProvider extends ServiceProvider
     {
         $validator = $this->app->make(Factory::class);
 
-        // Define "unique" rule
+        // Define "mongolid_unique" rule
         $validator->extend('mongolid_unique', Rules::class.'@unique');
         $validator->replacer('mongolid_unique', Rules::class.'@message');
 
-        // Define "exists" rule
+        // Define "mongolid_exists" rule
         $validator->extend('mongolid_exists', Rules::class.'@exists');
         $validator->replacer('mongolid_exists', Rules::class.'@message');
+
+        // Define "object_id" rule
+        $validator->extend('object_id', Rules::class.'@objectId');
+        $validator->replacer('object_id', Rules::class.'@objectIdMessage');
     }
 }

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -203,15 +203,12 @@ class MongolidServiceProvider extends ServiceProvider
     {
         $validator = $this->app->make(Factory::class);
 
-        // Define "mongolid_unique" rule
         $validator->extend('mongolid_unique', Rules::class.'@unique');
         $validator->replacer('mongolid_unique', Rules::class.'@message');
 
-        // Define "mongolid_exists" rule
         $validator->extend('mongolid_exists', Rules::class.'@exists');
         $validator->replacer('mongolid_exists', Rules::class.'@message');
 
-        // Define "object_id" rule
         $validator->extend('object_id', Rules::class.'@objectId');
         $validator->replacer('object_id', Rules::class.'@objectIdMessage');
     }

--- a/src/MongolidServiceProvider.php
+++ b/src/MongolidServiceProvider.php
@@ -3,6 +3,7 @@
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Validation\Factory;
 use Illuminate\Queue\Failed\NullFailedJobProvider;
 use Illuminate\Support\ServiceProvider;
 use Mongolid\Connection\Connection;
@@ -10,6 +11,7 @@ use Mongolid\Connection\Pool;
 use Mongolid\Container\Ioc as MongolidIoc;
 use Mongolid\Event\EventTriggerService;
 use Mongolid\Util\CacheComponentInterface;
+use MongolidLaravel\Validation\Rules;
 
 class MongolidServiceProvider extends ServiceProvider
 {
@@ -36,6 +38,8 @@ class MongolidServiceProvider extends ServiceProvider
         $this->extendsAuthManager();
 
         $this->replaceQueueFailer();
+
+        $this->createValidationRules();
     }
 
     /**
@@ -193,5 +197,18 @@ class MongolidServiceProvider extends ServiceProvider
         return new MongolidFailedJobProvider(
             $app->makeWith(FailedJobsService::class, compact('collection'))
         );
+    }
+
+    private function createValidationRules(): void
+    {
+        $validator = $this->app->make(Factory::class);
+
+        // Define "unique" rule
+        $validator->extend('mongolid_unique', Rules::class.'@unique');
+        $validator->replacer('mongolid_unique', Rules::class.'@message');
+
+        // Define "exists" rule
+        $validator->extend('mongolid_exists', Rules::class.'@exists');
+        $validator->replacer('mongolid_exists', Rules::class.'@message');
     }
 }

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -1,0 +1,125 @@
+<?php
+namespace MongolidLaravel\Validation;
+
+use InvalidArgumentException;
+use MongoDB\BSON\ObjectId;
+use Mongolid\Connection\Pool;
+use Mongolid\Util\ObjectIdUtils;
+
+class Rules
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    public function __construct(Pool $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * mongolid_unique:collection,field?,except?,idField?
+     *
+     * @see https://laravel.com/docs/5.5/validation#rule-unique
+     */
+    public function unique(string $attribute, $value, array $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'mongolid_unique');
+        $collection = $parameters[0];
+        $field = $parameters[1] ?? $attribute;
+        $query = [$field => $this->transformIfId($value)];
+
+        if ($except = $parameters[2] ?? false) {
+            $idColumn = $parameters[3] ?? '_id';
+
+            $query += [$idColumn => ['$ne' => $this->transformIfId($except)]];
+        }
+
+        return !$this->hasResults($collection, $query);
+    }
+
+    /**
+     * mongolid_exists:collection,field?
+     *
+     * @see https://laravel.com/docs/5.5/validation#rule-exists
+     */
+    public function exists(string $attribute, $value, array $parameters)
+    {
+        $this->requireParameterCount(1, $parameters, 'mongolid_exists');
+        $collection = $parameters[0];
+        $field = $parameters[1] ?? $attribute;
+
+        return $this->hasResults($collection, [$field => $this->transformIfId($value)]);
+    }
+
+    /**
+     * Error message with fallback from Laravel rules 'unique' and 'exists'.
+     */
+    public function message(string $message, string $attribute, string $rule): string
+    {
+        if ("validation.{$rule}" !== $message) {
+            return $message;
+        }
+
+        return $this->getTranslatedMessageFallback(
+            str_replace('mongolid_', '', $rule),
+            $attribute
+        );
+    }
+
+    /**
+     * Require a certain number of parameters to be present.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function requireParameterCount(int $count, array $parameters, string $rule): void
+    {
+        if (count($parameters) < $count) {
+            throw new InvalidArgumentException("Validation rule {$rule} requires at least {$count} parameters.");
+        }
+    }
+
+    /**
+     * Run query on database and check for a result count.
+     */
+    private function hasResults(string $collection, array $query): bool
+    {
+        $mongolidConnection = $this->pool->getConnection();
+        $connection = $mongolidConnection->getRawConnection();
+        $database = $mongolidConnection->defaultDatabase;
+
+        return (bool) $connection->$database->$collection->count($query);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function transformIfId($value)
+    {
+        if ($value && ObjectIdUtils::isObjectId($value)) {
+            $value = new ObjectId($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * If the user has not created a translation for 'mongolid_unique' rule,
+     * this method will attempt to get the translation for 'unique' rule.
+     * The same with 'mongolid_exists' and 'exists'.
+     * Since it is not easy to use the framework to make this message, this
+     * is a simple approach.
+     */
+    private function getTranslatedMessageFallback(string $rule, string $attribute): string
+    {
+        $attributeKey = "validation.attributes.$attribute";
+        $attributeTranslation = trans($attributeKey);
+
+        $attribute = $attributeTranslation === $attributeKey ? $attribute : $attributeTranslation;
+
+        return trans("validation.{$rule}", compact('attribute'));
+    }
+}

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -69,6 +69,32 @@ class Rules
     }
 
     /**
+     * Given attribute should be an ObjectId
+     * object_id
+     *
+     * @see ObjectId
+     */
+    public function objectId(string $attribute, $value)
+    {
+        return $this->isObjectId($value);
+    }
+
+    /**
+     * Given attribute should be an ObjectId
+     * object_id
+     *
+     * @see ObjectId
+     */
+    public function objectIdMessage(string $message, string $attribute, string $rule)
+    {
+        if ("validation.{$rule}" !== $message) {
+            return $message;
+        }
+
+        return "The {$attribute} must be an MongoDB ObjectId.";
+    }
+
+    /**
      * Require a certain number of parameters to be present.
      *
      * @throws InvalidArgumentException
@@ -99,7 +125,7 @@ class Rules
      */
     private function transformIfId($value)
     {
-        if ($value && ObjectIdUtils::isObjectId($value)) {
+        if ($value && $this->isObjectId($value)) {
             $value = new ObjectId($value);
         }
 
@@ -121,5 +147,13 @@ class Rules
         $attribute = $attributeTranslation === $attributeKey ? $attribute : $attributeTranslation;
 
         return trans("validation.{$rule}", compact('attribute'));
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function isObjectId($value): bool
+    {
+        return ObjectIdUtils::isObjectId($value);
     }
 }

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -21,7 +21,19 @@ class Rules
     /**
      * mongolid_unique:collection,field?,except?,idField?
      *
-     * @see https://laravel.com/docs/5.5/validation#rule-unique
+     * @example Using attribute name as query field
+     *   'email' => mongolid_unique:users
+     *
+     * @example Using other query field
+     *   'email' => mongolid_unique:users,user_email
+     *
+     * @example Excluding itself from verification
+     *   'email' => mongolid_unique:users,email,5ba3bc0836e5eb03f12a3c31
+     *
+     * @example Excluding itself from verification using other field for Id
+     *   'email' => mongolid_unique:users,email,5ba3bc0836e5eb03f12a3c31,user_id
+     *
+     * @see https://laravel.com/docs/5.6/validation#rule-unique
      */
     public function unique(string $attribute, $value, array $parameters)
     {
@@ -42,7 +54,13 @@ class Rules
     /**
      * mongolid_exists:collection,field?
      *
-     * @see https://laravel.com/docs/5.5/validation#rule-exists
+     * @example Using attribute name as query field
+     *   'email' => mongolid_exists:users
+     *
+     * @example Using other query field
+     *   'email' => mongolid_exists:users,user_email
+     *
+     * @see https://laravel.com/docs/5.6/validation#rule-exists
      */
     public function exists(string $attribute, $value, array $parameters)
     {
@@ -71,6 +89,9 @@ class Rules
     /**
      * Given attribute should be an ObjectId
      * object_id
+     *
+     * @example Using attribute name as query field
+     *   'product_id' => object_id
      *
      * @see ObjectId
      */

--- a/tests/FailedJobsServiceTest.php
+++ b/tests/FailedJobsServiceTest.php
@@ -13,15 +13,6 @@ use stdClass;
 
 class FailedJobsServiceTest extends TestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
-    {
-        m::close();
-        parent::tearDown();
-    }
-
     public function testAllShouldReturnWholeCollection()
     {
         // Set

--- a/tests/FailedJobsServiceTest.php
+++ b/tests/FailedJobsServiceTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Mockery as m;
@@ -10,7 +9,6 @@ use MongoDB\DeleteResult;
 use MongoDB\InsertOneResult;
 use Mongolid\Connection\Pool;
 use Mongolid\Connection\Connection;
-use TestCase;
 use stdClass;
 
 class FailedJobsServiceTest extends TestCase

--- a/tests/LaravelCacheComponentTest.php
+++ b/tests/LaravelCacheComponentTest.php
@@ -1,10 +1,8 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Illuminate\Cache\Repository;
 use Mockery as m;
-use TestCase;
 
 class LaravelCacheComponentTest extends TestCase
 {

--- a/tests/LaravelEventTriggerTest.php
+++ b/tests/LaravelEventTriggerTest.php
@@ -1,11 +1,9 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Mockery as m;
 use MongoDB\BSON\ObjectID;
-use TestCase;
 
 class LaravelEventTriggerTest extends TestCase
 {

--- a/tests/MongolidFailedJobProviderTest.php
+++ b/tests/MongolidFailedJobProviderTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace MongolidLaravel;
 
 use ArrayObject;
@@ -10,7 +9,6 @@ use MongoDB\BSON\UTCDateTime;
 use MongoDB\DeleteResult;
 use MongoDB\InsertOneResult;
 use Mongolid\Util\LocalDateTime;
-use TestCase;
 
 class MongolidFailedJobProviderTest extends TestCase
 {

--- a/tests/MongolidFailedJobProviderTest.php
+++ b/tests/MongolidFailedJobProviderTest.php
@@ -12,15 +12,6 @@ use Mongolid\Util\LocalDateTime;
 
 class MongolidFailedJobProviderTest extends TestCase
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function tearDown()
-    {
-        m::close();
-        parent::tearDown();
-    }
-
     public function testLogShouldPersistFailedJob()
     {
         // Set

--- a/tests/MongolidModelTest.php
+++ b/tests/MongolidModelTest.php
@@ -33,7 +33,7 @@ class MongolidModelTest extends TestCase
     {
         // Set
         $model = new class() extends MongolidModel {
-            public $rules = [
+            protected $rules = [
                 'name' => 'required',
                 'address' => 'min:100',
             ];

--- a/tests/MongolidModelTest.php
+++ b/tests/MongolidModelTest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Hashing\Hasher;
@@ -11,7 +10,6 @@ use Mongolid\Connection\Pool;
 use Mongolid\Cursor\Cursor;
 use Mongolid\DataMapper\DataMapper;
 use Mongolid\Exception\ModelNotFoundException;
-use TestCase;
 
 class MongolidModelTest extends TestCase
 {

--- a/tests/MongolidServiceProviderTest.php
+++ b/tests/MongolidServiceProviderTest.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Mongolid\Connection\Pool;
 use Mongolid\Container\Ioc;
 use Mongolid\Event\EventTriggerService;
 use Mongolid\Util\CacheComponentInterface;
-use TestCase;
 
 class MongolidServiceProviderTest extends TestCase
 {

--- a/tests/MongolidUserProviderTest.php
+++ b/tests/MongolidUserProviderTest.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Hashing\Hasher;
 use Mockery as m;
 use MongoDB\BSON\ObjectID;
-use TestCase;
 
 class MongolidUserProviderTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,8 +1,11 @@
 <?php
+namespace MongolidLaravel;
 
+use Mockery as m;
 use Mongolid\Container\Ioc;
+use Orchestra\Testbench\TestCase as BaseTestCase;
 
-class TestCase extends Orchestra\Testbench\TestCase
+class TestCase extends BaseTestCase
 {
     /**
      * {@inheritdoc}
@@ -26,7 +29,7 @@ class TestCase extends Orchestra\Testbench\TestCase
      */
     protected function expectEquals($expected, float $delta = 100)
     {
-        return Mockery::on(
+        return m::on(
              function ($value) use ($expected, $delta) {
                  $this->assertEquals($expected, $value, '', $delta);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,10 +10,16 @@ class TestCase extends BaseTestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         Ioc::setContainer($this->app);
+    }
+
+    protected function tearDown()
+    {
+        m::close();
+        parent::tearDown();
     }
 
     /**

--- a/tests/UTCDateTimeComparator.php
+++ b/tests/UTCDateTimeComparator.php
@@ -1,4 +1,5 @@
 <?php
+namespace MongolidLaravel;
 
 use MongoDB\BSON\UTCDateTime;
 use SebastianBergmann\Comparator\Comparator;

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -251,4 +251,72 @@ class RulesTest extends TestCase
         // Assertions
         $this->assertSame($result, $expectedMessage);
     }
+
+    public function testShouldBeAnObjectIdWhenUsingObject()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        // Actions
+        $result = $rules->objectId('_id', new ObjectId());
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldBeAnObjectIdWhenUsingString()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        // Actions
+        $result = $rules->objectId('productBank', (string) (new ObjectId()));
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldNotBeAnObjectId()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        // Actions
+        $result = $rules->objectId('productBank', '1234');
+
+        // Assertions
+        $this->assertFalse($result);
+    }
+
+    public function testShouldRetrieveAlreadyTranslatedMessageForObjectId()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+        $message = 'You shall not pass';
+
+        // Actions
+        $result = $rules->objectIdMessage($message, '_id', 'object_id');
+
+        // Assertions
+        $this->assertSame($result, $message);
+    }
+
+    public function testShouldTranslateAMessageForObjectId()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+        $expectedMessage = 'The productBank must be an MongoDB ObjectId.';
+
+        // Actions
+        $result = $rules->objectIdMessage('validation.object_id', 'productBank', 'object_id');
+
+        // Assertions
+        $this->assertSame($result, $expectedMessage);
+    }
+
 }

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -1,0 +1,254 @@
+<?php
+namespace MongolidLaravel\Validation;
+
+use Mockery as m;
+use MongoDB\BSON\ObjectId;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Database;
+use Mongolid\Connection\Connection;
+use Mongolid\Connection\Pool;
+use MongolidLaravel\TestCase;
+
+class RulesTest extends TestCase
+{
+    public function testShouldBeUnique()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count(['email' => 'john@doe.com'])
+            ->andReturn(0);
+
+        // Actions
+        $result = $rules->unique('email', 'john@doe.com', ['users']);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldBeUniqueExcludingId()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $parameters = ['users', 'email_field', '5ba3a7c936e5eb038a118521'];
+
+        $query = [
+            'email_field' => 'john@doe.com',
+            '_id' => ['$ne' => new ObjectId('5ba3a7c936e5eb038a118521')],
+        ];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count($query)
+            ->andReturn(0);
+
+        // Actions
+        $result = $rules->unique('email', 'john@doe.com', $parameters);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldNotBeUniqueWhenThereAreResults()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $parameters = ['users', 'email_field', '5ba3a7c936e5eb038a118521', 'parent'];
+
+        $query = [
+            'email_field' => 'john@doe.com',
+            'parent' => ['$ne' => new ObjectId('5ba3a7c936e5eb038a118521')],
+        ];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count($query)
+            ->andReturn(1);
+
+        // Actions
+        $result = $rules->unique('email', 'john@doe.com', $parameters);
+
+        // Assertions
+        $this->assertFalse($result);
+    }
+
+    public function testShouldExist()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count(['email' => 'john@doe.com'])
+            ->andReturn(1);
+
+        // Actions
+        $result = $rules->exists('email', 'john@doe.com', ['users']);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldNotExistWhenThereIsNoResults()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count(['email_field' => 'john@doe.com'])
+            ->andReturn(0);
+
+        // Actions
+        $result = $rules->exists('email', 'john@doe.com', ['users', 'email_field']);
+
+        // Assertions
+        $this->assertFalse($result);
+    }
+
+    public function testShouldRetrieveAlreadyTranslatedMessage()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+        $message = 'The email should be unique yo';
+
+        // Actions
+        $result = $rules->message($message, 'email', 'mongolid_unique');
+
+        // Assertions
+        $this->assertSame($result, $message);
+    }
+
+    public function testShouldTranslateAMessage()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+        $expectedMessage = 'The email has already been taken.';
+
+        // Actions
+        $result = $rules->message('validation.mongolid_unique', 'email', 'mongolid_unique');
+
+        // Assertions
+        $this->assertSame($result, $expectedMessage);
+    }
+}

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace MongolidLaravel\Validation;
 
+use InvalidArgumentException;
 use Mockery as m;
 use MongoDB\BSON\ObjectId;
 use MongoDB\Client;
@@ -144,6 +145,26 @@ class RulesTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testUniqueShouldValidateParameters()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $parameters = [];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->never();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule mongolid_unique requires at least 1 parameters.');
+
+        // Actions
+        $rules->unique('email', 'john@doe.com', $parameters);
+    }
+
     public function testShouldExist()
     {
         // Set
@@ -222,6 +243,26 @@ class RulesTest extends TestCase
 
         // Assertions
         $this->assertFalse($result);
+    }
+
+    public function testExistsShouldValidateParameters()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $parameters = [];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->never();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Validation rule mongolid_exists requires at least 1 parameters.');
+
+        // Actions
+        $rules->exists('email', 'john@doe.com', $parameters);
     }
 
     public function testShouldRetrieveAlreadyTranslatedMessage()
@@ -318,5 +359,4 @@ class RulesTest extends TestCase
         // Assertions
         $this->assertSame($result, $expectedMessage);
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace MongolidLaravel;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use SebastianBergmann\Comparator\Factory;


### PR DESCRIPTION
Creates `mongolid_unique` and `mongolid_exists` validation rules, just like  [`unique`](https://laravel.com/docs/5.5/validation#rule-unique) and [`exists`](https://laravel.com/docs/5.5/validation#rule-exists) rules from the framework.

Besides, now we must use `$model->rules()` instead of  `$model->rules`. This gives way more flexibility and we don't need to increment rules on the constructor or something like it.

The motivation is to have dynamic `unique` rule parameters, like:
```php
public function rules()
{
    $rules = $this->rules;

    // the _id would not exist if it sat on the constructor and thus the rule would be wrong.
    $rules['name'] = "mongolid_unique:{$this->getCollectionName()},name,{$this->_id}";

    return $rules;
}
```


The `object_id` rule is created too, so that we can ensure that a field has a valid `MongoDB\BSON\ObjectId`.