### PR TITLE
Handle int id on unique rule

### DIFF
--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -46,9 +46,9 @@ class Rules
         $query = [$field => $this->transformIfId($value)];
 
         if ($except = $parameters[2] ?? false) {
-            $idColumn = !empty($parameters[3]) ? $parameters[3] : '_id';
+            $idColumn = $parameters[3] ?? '_id';
 
-            if ($parameters[4] ?? false) {
+            if ('true' === ($parameters[4] ?? false)) {
                 $except = (int) $except;
             }
 

--- a/src/Validation/Rules.php
+++ b/src/Validation/Rules.php
@@ -19,7 +19,7 @@ class Rules
     }
 
     /**
-     * mongolid_unique:collection,field?,except?,idField?
+     * mongolid_unique:collection,field?,except?,idField?,isInt?
      *
      * @example Using attribute name as query field
      *   'email' => mongolid_unique:users
@@ -33,6 +33,9 @@ class Rules
      * @example Excluding itself from verification using other field for Id
      *   'email' => mongolid_unique:users,email,5ba3bc0836e5eb03f12a3c31,user_id
      *
+     * @example Excluding itself from verification using other field for Id and casting Id to int
+     *   'email' => mongolid_unique:users,email,5ba3bc0836e5eb03f12a3c31,user_id,true
+     *
      * @see https://laravel.com/docs/5.6/validation#rule-unique
      */
     public function unique(string $attribute, $value, array $parameters)
@@ -43,7 +46,11 @@ class Rules
         $query = [$field => $this->transformIfId($value)];
 
         if ($except = $parameters[2] ?? false) {
-            $idColumn = $parameters[3] ?? '_id';
+            $idColumn = !empty($parameters[3]) ? $parameters[3] : '_id';
+
+            if ($parameters[4] ?? false) {
+                $except = (int) $except;
+            }
 
             $query += [$idColumn => ['$ne' => $this->transformIfId($except)]];
         }

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -145,6 +145,98 @@ class RulesTest extends TestCase
         $this->assertFalse($result);
     }
 
+    public function testShouldBeUniqueCastingIdToInt()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $parameters = ['users', 'email_field', '88991122', 'id', 'true'];
+
+        $query = [
+            'email_field' => 'john@doe.com',
+            'id' => ['$ne' => 88991122],
+        ];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count($query)
+            ->andReturn(0);
+
+        // Actions
+        $result = $rules->unique('email', 'john@doe.com', $parameters);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldBeUniqueCastingIdToIntUsingDefaultIdKey()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+        $parameters = ['users', 'email_field', '1234', '', 'true'];
+
+        $query = [
+            'email_field' => 'john@doe.com',
+            '_id' => ['$ne' => 1234],
+        ];
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count($query)
+            ->andReturn(0);
+
+        // Actions
+        $result = $rules->unique('email', 'john@doe.com', $parameters);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
     public function testUniqueShouldValidateParameters()
     {
         // Set
@@ -200,6 +292,46 @@ class RulesTest extends TestCase
 
         // Actions
         $result = $rules->exists('email', 'john@doe.com', ['users']);
+
+        // Assertions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldExistWithIntValue()
+    {
+        // Set
+        $pool = m::mock(Pool::class);
+        $rules = new Rules($pool);
+
+        $connection = m::mock(Connection::class);
+        $connection->defaultDatabase = 'mongolid';
+        $client = m::mock(Client::class);
+        $database = m::mock(Database::class);
+        $collection = m::mock(Collection::class);
+
+        // Expectations
+        $pool->expects()
+            ->getConnection()
+            ->andReturn($connection);
+
+        $connection->expects()
+            ->getRawConnection()
+            ->andReturn($client);
+
+        $client->expects()
+            ->selectDatabase('mongolid')
+            ->andReturn($database);
+
+        $database->expects()
+            ->selectCollection('users')
+            ->andReturn($collection);
+
+        $collection->expects()
+            ->count(['user_id' => 1234])
+            ->andReturn(1);
+
+        // Actions
+        $result = $rules->exists('user_id', 1234, ['users']);
 
         // Assertions
         $this->assertTrue($result);

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -191,7 +191,7 @@ class RulesTest extends TestCase
         $this->assertTrue($result);
     }
 
-    public function testShouldBeUniqueCastingIdToIntUsingDefaultIdKey()
+    public function testShouldNotCastIdToIntIfParameterIsNotStringTrue()
     {
         // Set
         $pool = m::mock(Pool::class);
@@ -202,11 +202,11 @@ class RulesTest extends TestCase
         $client = m::mock(Client::class);
         $database = m::mock(Database::class);
         $collection = m::mock(Collection::class);
-        $parameters = ['users', 'email_field', '1234', '', 'true'];
+        $parameters = ['users', 'email_field', '88991122', 'id', 'foo'];
 
         $query = [
             'email_field' => 'john@doe.com',
-            '_id' => ['$ne' => 1234],
+            'id' => ['$ne' => '88991122'],
         ];
 
         // Expectations


### PR DESCRIPTION
When using `mongolid_unique` we need a way to cast the  `idField` to `int`