### PR TITLE
Allow custom validation messages

### DIFF
--- a/src/MongolidModel.php
+++ b/src/MongolidModel.php
@@ -135,7 +135,7 @@ abstract class MongolidModel extends ActiveRecord
         }
 
         // Creates validator with attributes and the rules of the object
-        $validator = app(ValidationFactory::class)->make($attributes, $rules);
+        $validator = app(ValidationFactory::class)->make($attributes, $rules, $this->messages());
 
         // Validate and attach errors
         if ($hasErrors = $validator->fails()) {
@@ -165,6 +165,15 @@ abstract class MongolidModel extends ActiveRecord
     public function rules(): array
     {
         return $this->rules ?? [];
+    }
+
+
+    /**
+     * Get custom messages for validation errors.
+     */
+    public function messages(): array
+    {
+        return [];
     }
 
     /**

--- a/tests/MongolidModelTest.php
+++ b/tests/MongolidModelTest.php
@@ -60,7 +60,7 @@ class MongolidModelTest extends TestCase
                 'name' => 'required',
             ];
 
-            public function messages()
+            public function messages(): array
             {
                 return [
                     'name.required' => 'The name must be fielded.',

--- a/tests/MongolidModelTest.php
+++ b/tests/MongolidModelTest.php
@@ -52,6 +52,34 @@ class MongolidModelTest extends TestCase
         $this->assertEquals($expectedErrors, $model->errors()->all());
     }
 
+    public function testShouldValidateRulesWithCustomMessage()
+    {
+        // Set
+        $model = new class() extends MongolidModel {
+            protected $rules = [
+                'name' => 'required',
+            ];
+
+            public function messages()
+            {
+                return [
+                    'name.required' => 'The name must be fielded.',
+                ];
+            }
+        };
+
+        $expectedErrors = [
+            'The name must be fielded.',
+        ];
+
+        // Actions
+        $result = $model->isValid();
+
+        // Assertions
+        $this->assertFalse($result);
+        $this->assertEquals($expectedErrors, $model->errors()->all());
+    }
+
     public function testValidateShouldSkipUnchangedHashedAttributes()
     {
         // Set


### PR DESCRIPTION
Inspired by [Custom Error Messages](https://laravel.com/docs/5.7/validation#custom-error-messages).