### PR TITLE
Change fire() to dispatch() for Laravel 5.8

### DIFF
--- a/src/LaravelEventTrigger.php
+++ b/src/LaravelEventTrigger.php
@@ -40,6 +40,6 @@ class LaravelEventTrigger implements EventTriggerInterface
      */
     public function fire(string $event, $payload, bool $halt)
     {
-        return $this->dispatcher->fire($event, $payload, $halt);
+        return $this->dispatcher->dispatch($event, $payload, $halt);
     }
 }


### PR DESCRIPTION
Event Dispatcher function fire() has been deprecated in Larvel 5.8 as described here: https://github.com/kristijanhusak/laravel-form-builder/issues/492. The dispatch() function is the updated way to call this functionality. I have made the change here to add compatibility.