### PR TITLE
Fix event dispatcher compatibility with newer versions

### DIFF
--- a/src/LaravelEventTrigger.php
+++ b/src/LaravelEventTrigger.php
@@ -40,6 +40,10 @@ class LaravelEventTrigger implements EventTriggerInterface
      */
     public function fire(string $event, $payload, bool $halt)
     {
-        return $this->dispatcher->fire($event, $payload, $halt);
+        if (method_exists($this->dispatcher, 'fire')) {
+            return $this->dispatcher->fire($event, $payload, $halt);
+        }
+
+        return $this->dispatcher->dispatch($event, $payload, $halt);
     }
 }

--- a/tests/LaravelEventTriggerTest.php
+++ b/tests/LaravelEventTriggerTest.php
@@ -10,7 +10,47 @@ class LaravelEventTriggerTest extends TestCase
     public function testShouldFire()
     {
         // Set
-        $dispatcher = m::mock(Dispatcher::class);
+        $dispatcher = m::mock(new class implements Dispatcher {
+            public function fire($event, $payload = [], $halt = false)
+            {
+            }
+
+            public function listen($events, $listener = null)
+            {
+            }
+
+            public function hasListeners($eventName)
+            {
+            }
+
+            public function subscribe($subscriber)
+            {
+            }
+
+            public function until($event, $payload = [])
+            {
+            }
+
+            public function dispatch($event, $payload = [], $halt = false)
+            {
+            }
+
+            public function push($event, $payload = [])
+            {
+            }
+
+            public function flush($event)
+            {
+            }
+
+            public function forget($event)
+            {
+            }
+
+            public function forgetPushed()
+            {
+            }
+        });
         $trigger = new LaravelEventTrigger($dispatcher);
         $event = 'collection:saved';
         $payload = ['_id' => new ObjectID()];
@@ -18,6 +58,28 @@ class LaravelEventTriggerTest extends TestCase
 
         // Expectations
         $dispatcher->shouldReceive('fire')
+            ->once()
+            ->with($event, $payload, $halt)
+            ->andReturn(true);
+
+        // Actions
+        $result = $trigger->fire($event, $payload, $halt);
+
+        // Actions
+        $this->assertTrue($result);
+    }
+
+    public function testShouldFireOnNewerVersions()
+    {
+        // Set
+        $dispatcher = m::mock(Dispatcher::class);
+        $trigger = new LaravelEventTrigger($dispatcher);
+        $event = 'collection:saved';
+        $payload = ['_id' => new ObjectID()];
+        $halt = false;
+
+        // Expectations
+        $dispatcher->shouldReceive('dispatch')
             ->once()
             ->with($event, $payload, $halt)
             ->andReturn(true);


### PR DESCRIPTION
The `fire` method was deprecated and removed. This change keeps both versions compatible.