### PR TITLE
fix(UserProvider): docblock for $model

### DIFF
--- a/src/MongolidUserProvider.php
+++ b/src/MongolidUserProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -26,8 +25,6 @@ class MongolidUserProvider implements UserProvider
     /**
      * Create a new database user provider.
      *
-     * @param HasherContract $hasher
-     * 
      * @param string $model
      * Class::class instanceof \MongolidLaravel\MongoLidModel
      */
@@ -84,7 +81,7 @@ class MongolidUserProvider implements UserProvider
      */
     protected function createModel()
     {
-        $class = '\\' . ltrim($this->model, '\\');
+        $class = '\\'.ltrim($this->model, '\\');
 
         return Ioc::make($class);
     }

--- a/src/MongolidUserProvider.php
+++ b/src/MongolidUserProvider.php
@@ -18,7 +18,7 @@ class MongolidUserProvider implements UserProvider
     /**
      * The MongoLid user model.
      *
-     * @var string|\MongolidLaravel\MongoLidModel $model
+     * @var string $model
      */
     protected $model;
 

--- a/src/MongolidUserProvider.php
+++ b/src/MongolidUserProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace MongolidLaravel;
 
 use Illuminate\Contracts\Auth\Authenticatable as UserContract;
@@ -18,14 +19,17 @@ class MongolidUserProvider implements UserProvider
     /**
      * The MongoLid user model.
      *
-     * @var \MongolidLaravel\MongoLidModel
+     * @var string|\MongolidLaravel\MongoLidModel $model
      */
     protected $model;
 
     /**
      * Create a new database user provider.
      *
-     * @param \MongolidLaravel\MongoLidModel $model
+     * @param HasherContract $hasher
+     * 
+     * @param string $model
+     * Class::class instanceof \MongolidLaravel\MongoLidModel
      */
     public function __construct(HasherContract $hasher, $model)
     {
@@ -80,7 +84,7 @@ class MongolidUserProvider implements UserProvider
      */
     protected function createModel()
     {
-        $class = '\\'.ltrim($this->model, '\\');
+        $class = '\\' . ltrim($this->model, '\\');
 
         return Ioc::make($class);
     }


### PR DESCRIPTION
Resolve #143 issue.

Wrong doc block make linters (as Psalm) to erroneous mark as an error if pass a class even if has a heritage from MongolidLaravel\MongoLidModel.